### PR TITLE
Fix timestamp issue

### DIFF
--- a/sync-windows-app/sync-windows-app.Shared/MainPage.xaml.cs
+++ b/sync-windows-app/sync-windows-app.Shared/MainPage.xaml.cs
@@ -143,6 +143,7 @@ namespace sync_windows_app
         public string Name { set; get; }
 
         [JsonProperty("created")]
+        [JsonConverter(typeof(MillisecondEpochConverter))]
         public DateTime Created { set; get; }
 
         [JsonIgnore]
@@ -181,6 +182,22 @@ namespace sync_windows_app
         public object ConvertBack(object value, Type targetType, object parameter, string culture)
         {
             return new NotImplementedException();
+        }
+    }
+
+    public class MillisecondEpochConverter : Newtonsoft.Json.Converters.DateTimeConverterBase
+    {
+        private static readonly DateTime _epoch = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            writer.WriteRawValue(Convert.ToInt64(((DateTime)value - _epoch).TotalMilliseconds).ToString());
+        }
+
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            if (reader.Value == null) { return null; }
+            return _epoch.AddMilliseconds(Int64.Parse(reader.Value.ToString()));
         }
     }
 }

--- a/sync-windows-app/sync-windows-app.Shared/fhconfig.json
+++ b/sync-windows-app/sync-windows-app.Shared/fhconfig.json
@@ -1,8 +1,8 @@
 ﻿{
-  "host": "",
-  "appid": "",
-  "apptitle": "",
-  "projectid": "",
-  "appkey": "",
-  "connectiontag": ""
+  "appid": "5buuz6m42v3eydmtouzyevhs",
+  "appkey": "556e2231544287fafa5009d131f3908be13e4c14",
+  "apptitle": "windowsapp",
+  "connectiontag": "0.0.1",
+  "host": "https://testing.zeta.feedhenry.com",
+  "projectid": "5buuz6nm75furxj2um4e3psg"
 }

--- a/sync-windows-app/sync-windows-app.Shared/fhconfig.json
+++ b/sync-windows-app/sync-windows-app.Shared/fhconfig.json
@@ -1,8 +1,8 @@
 ﻿{
-  "appid": "5buuz6m42v3eydmtouzyevhs",
-  "appkey": "556e2231544287fafa5009d131f3908be13e4c14",
-  "apptitle": "windowsapp",
-  "connectiontag": "0.0.1",
-  "host": "https://testing.zeta.feedhenry.com",
-  "projectid": "5buuz6nm75furxj2um4e3psg"
+  "appid": "",
+  "appkey": "",
+  "apptitle": "",
+  "connectiontag": "",
+  "host": "",
+  "projectid": ""
 }


### PR DESCRIPTION
## Why

While testing the app for the new sync backend, I noticed that the remote changes are not appeared in the app.

After investigation, it turns out that all other platform will create timestamp in Epoch format, which doesn't work with the default `DateTime` converter in Json.Net.

## What

Add a new converter for the time stamp value. Keep it consistent with the sample app on other platforms
